### PR TITLE
Storing Tokens instead of Transactions

### DIFF
--- a/src/main/java/com/example/NewRelicTransactionProblem/AsyncClientConfig.java
+++ b/src/main/java/com/example/NewRelicTransactionProblem/AsyncClientConfig.java
@@ -73,6 +73,10 @@ public class AsyncClientConfig {
                             try (NewRelicToken token = context.createToken()) {
                                 NewRelic.addCustomParameter("Second interceptor", true);
                                 chain.proceed(request, entityProducer, scope, asyncExecCallback);
+                                // looks like this is the last interceptor, so we can expire the token here
+                                // I tested this without this expire. I was able to see the attributes in the transaction
+                                // but since the token was not expired, it took a few minutes for the transaction to show up in the UI.
+                                token.expire();
                             }
                         }
                     }

--- a/src/main/java/com/example/NewRelicTransactionProblem/ThreadContext.java
+++ b/src/main/java/com/example/NewRelicTransactionProblem/ThreadContext.java
@@ -1,7 +1,7 @@
 package com.example.NewRelicTransactionProblem;
 
 import com.newrelic.api.agent.NewRelic;
-import com.newrelic.api.agent.Transaction;
+import com.newrelic.api.agent.Token;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,15 +13,16 @@ import java.util.StringJoiner;
 class ThreadContext extends HttpClientContext implements Closeable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ThreadContext.class);
-    private final Transaction transaction;
+    private final Token token;
 
     ThreadContext() {
         super();
-        transaction = NewRelic.getAgent().getTransaction();
+        // since this is run in the thread that has a transaction the token generated here is good.
+        token = NewRelic.getAgent().getTransaction().getToken();
     }
 
     public NewRelicToken createToken() {
-        return new NewRelicToken(transaction);
+        return new NewRelicToken(token);
     }
 
     @Override


### PR DESCRIPTION
The problem was that the way the Token was being generated does not work.

Transaction#getToken is a bit misleading because it only really works in the same thread where the Transaction is running.
So storing the Transaction and using it to get a Token in a different thread results in a NoOpToken being returned.

The solution is to store a Token instead.
But note that the Token has to be expired by the last interceptor, or else it will hold the Transaction open for a few minutes until the Token times out.